### PR TITLE
Add cursor pointer on Remove and Disqualify option

### DIFF
--- a/src/components/pages/teams/hero/hero.jsx
+++ b/src/components/pages/teams/hero/hero.jsx
@@ -84,12 +84,12 @@ const Hero = ({ team }) => {
                     {user.name}
                   </p>
                   {moderator && (
-                    <p className="truncate font-medium" onClick={kick(user.id)}>
+                    <p className="cursor-pointer truncate font-medium" onClick={kick(user.id)}>
                       Remove
                     </p>
                   )}
                   {moderator && (
-                    <p className="truncate font-medium" onClick={disqualifiedMember(user.id)}>
+                    <p className="cursor-pointer truncate font-medium" onClick={disqualifiedMember(user.id)}>
                       {user.disqualified ? 'Bring Back to the game' : 'Disqualify'}
                     </p>
                   )}


### PR DESCRIPTION
Currently, there is no cursor pointer on the Remove and Disqualify button. Due to this, it doesn't feel like they are clickable buttons, instead, feels like they are regular texts.
This pull request adds cursor pointer on those options.