### PR TITLE
Catch 500 errors when searching for a team

### DIFF
--- a/src/pages/api/team.js
+++ b/src/pages/api/team.js
@@ -3,11 +3,19 @@ import findUserAndTeam from '~/helpers/find.user.and.team';
 
 export default async (req, res) => {
   if (req.query.id) {
-    const normalTeam = await findTeam(req.query.id);
+    try {
+      const normalTeam = await findTeam(req.query.id);
+    } catch (error) {
+      res.status(404).json({ "I'm sorry but that team doesn't exist (yet), maybe you'll be the one to make it!" })
+    }
     res.status(200).json({ team: normalTeam });
     return;
   }
-
-  const { team, admin } = await findUserAndTeam(req, res);
+  
+  try {
+    const { team, admin } = await findUserAndTeam(req, res);
+  } catch (error) {
+    res.status(404).json({ "I'm sorry but that team doesn't exist (yet), maybe you'll be the one to make it!" })
+  }
   res.status(200).json({ team, admin });
 };


### PR DESCRIPTION
Currently, when a visits a team's page and it doesn't exist, it results in a 500, in this PR, I've (hopefully) fixed this by adding 2 simple try and catch blocks which, if an error occurs, it results in a 404 not found.