### PR TITLE
Fix update sign-up-button loading state

### DIFF
--- a/src/components/shared/sign-up-button/sign-up-button.jsx
+++ b/src/components/shared/sign-up-button/sign-up-button.jsx
@@ -2,14 +2,15 @@ import clsx from 'clsx';
 import { signIn, useSession } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import GitHubIcon from 'icons/github.inline.svg';
 
 const SignUpButton = ({ className, alternativeText }) => {
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingState, setIsLoadingState] = useState(false);
   const { status } = useSession();
   const router = useRouter();
+  const isLoading = useMemo(() => isLoadingState || status === 'loading', [isLoadingState, status]);
 
   const handleSignIn = (e) => {
     e.preventDefault();
@@ -17,7 +18,7 @@ const SignUpButton = ({ className, alternativeText }) => {
       router.push('/myteam');
       return;
     }
-    setIsLoading(true);
+    setIsLoadingState(true);
     signIn('github', { callbackUrl: '/thank-you/' });
   };
 


### PR DESCRIPTION
Fixed the [button text switching](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/540f4f65-b359-4e4c-ae15-39594e7ed58d/Untitled.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45EIPT3X45%2F20221003%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20221003T132029Z&X-Amz-Expires=86400&X-Amz-Signature=4b48ea0145756f69f83aec8aa1a7092abf5da3fd6ec38ba45b56c709dd30e950&X-Amz-SignedHeaders=host&response-content-disposition=filename%20%3D%22Untitled.mp4%22&x-id=GetObject) from one to another if you’re already sign up