### PR TITLE
fix: add focus indicator to buttons

### DIFF
--- a/src/components/shared/button/button.jsx
+++ b/src/components/shared/button/button.jsx
@@ -24,7 +24,7 @@ const Button = ({ className }) => {
   return (
     <button
       className={clsx(
-        'base-btn-animation relative inline-flex h-9 items-center justify-center whitespace-nowrap px-4 text-center !leading-none outline-none before:absolute before:inset-0 before:-z-10 before:border-2 after:absolute after:inset-0 after:-z-10',
+        'base-btn-animation relative inline-flex h-9 items-center justify-center whitespace-nowrap px-4 text-center !leading-none before:absolute before:inset-0 before:-z-10 before:border-2 after:absolute after:inset-0 after:-z-10',
         className,
         isLoading && 'pointer-events-none min-w-[135px]'
       )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -7,6 +7,10 @@
     @apply min-w-[320px] bg-black font-sans text-base leading-normal text-white antialiased;
     -webkit-tap-highlight-color: transparent;
   }
+  *:focus-visible {
+    outline: 2px transparent solid;
+    box-shadow: 0 0 0 2px #000, 0 0 0 4px #fff;
+  }
 }
 
 .coming-soon-animation span {


### PR DESCRIPTION
The buttons had no focus indicator which is an accessibility issue https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html

I removed the outline-none from the button component and also added a double focus-visible class to the global styles which will show up white on a black background and black on a white background and therefore work in different color schemes.