### PR TITLE
fix: add aria labels to icon only links and buttons

### DIFF
--- a/helpers/novu.js
+++ b/helpers/novu.js
@@ -22,7 +22,13 @@ const Novu = () => {
       applicationIdentifier={process.env.NEXT_PUBLIC_NOVU_APP_ID}
     >
       <PopoverNotificationCenter ref={ref} onNotificationClick={onClick}>
-        {({ unseenCount }) => <NotificationBell colorScheme="dark" unseenCount={unseenCount} />}
+        {({ unseenCount }) => (
+          <NotificationBell
+            colorScheme="dark"
+            unseenCount={unseenCount}
+            aria-label="Notifications"
+          />
+        )}
       </PopoverNotificationCenter>
     </NovuProvider>
   );

--- a/src/components/pages/joinsquad/hero/hero.jsx
+++ b/src/components/pages/joinsquad/hero/hero.jsx
@@ -55,6 +55,7 @@ const JoinSquad = () => (
             href="https://twitter.com/HackSquadDev"
             target="_blank"
             rel="noreferrer"
+            aria-label="Hacksquad Twitter (opens in new tab)"
           >
             <TwitterIcon className="h-[26px] transition-opacity duration-200 group-hover:opacity-80" />
           </a>
@@ -64,6 +65,7 @@ const JoinSquad = () => (
             href="https://discord.gg/vcqkXgT3Xr"
             target="_blank"
             rel="noreferrer"
+            aria-label="Hacksquad Discord (opens in new tab)"
           >
             <DiscordIcon className="h-[26px] transition-opacity duration-200 group-hover:opacity-80" />
           </a>

--- a/src/components/pages/team/hero/team.jsx
+++ b/src/components/pages/team/hero/team.jsx
@@ -140,7 +140,12 @@ const Team = ({ info }) => {
                   {user.name}
                 </p>
                 <p className="font-medium">
-                  <a href={`https://github.com/${user.handle}`} target="_blank" rel="noreferrer">
+                  <a
+                    href={`https://github.com/${user.handle}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label={`${user.name}'s Github (opens in new link)`}
+                  >
                     <GitHubIcon className="h-[30px]" />
                   </a>
                 </p>


### PR DESCRIPTION
Added aria labels to:
-the bell notification icon in the header
-the github logos on the team squad pages
-the twitter and discord links in the footer