### PR TITLE
fix: Update failure on deleting PRs

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,7 @@ enum ActionType {
 
 model ActionLogs {
   id              String      @id @default(cuid())
+  createdAt       DateTime    @default(now())
   // action type i.e. if is for PR or for user or team
   actionType      ActionType
   // id of the PR
@@ -82,7 +83,6 @@ model ActionLogs {
   // details of user who took the action
   admin           User        @relation("admin", fields: [adminId], references: [id])
   adminId         String
-  @@unique([pr, adminId], name: "prAdmin")
 }
 
 model Report {

--- a/src/pages/api/remove-pr.js
+++ b/src/pages/api/remove-pr.js
@@ -5,7 +5,9 @@ import prisma from '~/prisma/client';
 
 export default async function handler(req, res) {
   const { user } = await findUserAndTeam(req, res);
-  if (!user?.moderator || !user?.cleaner || !req?.query?.id) {
+
+  if (!req?.query?.id || !(user?.moderator || user?.cleaner)) {
+    res.json({ success: false, message: 'Invalid request' });
     return;
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fix a bug introduced by recent changes to the API
AND
Added **createdAt** to ActionLogs

## Why was this change needed?
Currently the following are breaking:
- `remove-api` because of the invalid cleaner, moderator check.
- `remove-api` because of unique constrains of `admin-pr`. This cannot be unique because same admin might delete the PR and recover it afterwards.

## Other information
I also noticed that there is a typo in the enum value of **ActionType** and there is `DELTE_PR` instead of `DELETE_PR`.
I can add this change to this same PR if necessary, however if we make this change, we will have to drop all of the existing actionLogs with the same enum value from the DB.