### PR TITLE
Add margin to bottom of socials

### DIFF
--- a/src/components/shared/socials/socials.jsx
+++ b/src/components/shared/socials/socials.jsx
@@ -7,7 +7,7 @@ import GithubIcon from 'images/social/github.inline.svg';
 import TwitterIcon from 'images/social/twitter.inline.svg';
 
 const Socials = ({ className: additionalClassName }) => (
-  <section className={clsx('flex items-center', additionalClassName)}>
+  <section className={clsx('flex items-center mb-20', additionalClassName)}>
     <div className="pr-8 text-center">
       <h2 className="font-mono font-medium uppercase">Let’s connect</h2>
       <div className="flex items-center justify-center space-x-8">


### PR DESCRIPTION
The socials section was previously touching the bottom of the page, I have no edited this to add a margin-bottom of 20px (equal to its already provided margin top)

This was necessary as it previously did not look correct